### PR TITLE
fix: 메인 페이지 스케줄 그리드 레이블 정렬 및 슬롯 개수 오류 수정

### DIFF
--- a/src/pages/main/MainPage.css
+++ b/src/pages/main/MainPage.css
@@ -63,7 +63,9 @@
   border: none;
   background-color: var(--bg-primary);
   border-radius: 999px 0 999px 999px;
-  box-shadow: 0px 1px 2px -1px #0000001a, 0px 1px 3px 0px #0000001a;
+  box-shadow:
+    0px 1px 2px -1px #0000001a,
+    0px 1px 3px 0px #0000001a;
   cursor: pointer;
 }
 
@@ -189,7 +191,6 @@
   --time-gap: 4px;
   --time-rail-y-shift: -3px;
 
-
   --frame-shift-x: 0px;
 
   --grid-w: calc(
@@ -226,6 +227,8 @@
 .schedule-date-row {
   display: flex;
   width: fit-content;
+  gap: var(--col-gap);
+  padding-right: var(--scroll-inset);
 }
 
 .schedule-date-header {
@@ -244,13 +247,14 @@
   left: var(--rail-left);
   width: var(--time-rail-w);
   height: var(--grid-h);
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: hidden;
   background: var(--bg-primary);
   z-index: 4;
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
+
 .schedule-time-rail::-webkit-scrollbar {
   display: none;
 }
@@ -258,6 +262,8 @@
 .schedule-time-col {
   display: flex;
   flex-direction: column;
+  gap: var(--row-gap);
+  padding-top: 1px;
 }
 
 .schedule-time-label {
@@ -267,7 +273,7 @@
   font-weight: 400;
   color: var(--text-primary);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-end;
   padding-right: 6px;
   box-sizing: border-box;
@@ -374,6 +380,7 @@
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
+
 .restaurant-rail--hidden-scrollbar::-webkit-scrollbar {
   display: none;
 }

--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -82,7 +82,7 @@ function buildTimeSlotsFromRange(startHm, endHm) {
   const slots = [];
   const labels = [];
 
-  while (startMin <= endMin) {
+  while (startMin < endMin) {
     const h = Math.floor(startMin / 60);
     const m = startMin % 60;
 
@@ -96,6 +96,14 @@ function buildTimeSlotsFromRange(startHm, endHm) {
 
     startMin += 30;
   }
+
+  // 종료 시각 레이블 추가 (슬롯은 추가하지 않음)
+  const eh2 = Math.floor(endMin / 60);
+  const em2 = endMin % 60;
+  const isPmEnd = eh2 >= 12;
+  const hour12End = ((eh2 + 11) % 12) + 1;
+  const ampmEnd = isPmEnd ? 'PM' : 'AM';
+  labels.push(em2 === 0 ? `${hour12End} ${ampmEnd}` : '');
 
   return { slots, labels };
 }
@@ -587,6 +595,10 @@ export default function MainPage() {
                               {timeLabels[rowIndex] ?? ''}
                             </div>
                           ))}
+                          {/* 종료 시각 레이블 */}
+                          <div className="schedule-time-label schedule-time-label--end">
+                            {timeLabels[timeSlots.length] ?? ''}
+                          </div>
                         </div>
                       </div>
 


### PR DESCRIPTION
- 슬롯 개수 오류: 종료 시각이 슬롯에 포함되던 문제 수정 (while <= → <)
- 시간 레이블 스크롤 이탈: time-rail overflow-y auto → hidden으로 변경
- 세로 레이블 드리프트: schedule-time-col에 gap/padding-top 추가 (그리드 row-gap 일치)
- 종료 시각 레이블 누락: buildTimeSlotsFromRange에서 end label 추가
- 가로 레이블 드리프트: schedule-date-row에 gap/padding-right 추가 (그리드 column-gap + scroll-inset 일치)
- 시간 텍스트 위치: align-items center → flex-start로 경계선에 정확히 표시