### PR TITLE
fix: JoinTimePage 모바일 그리드 UI 수정

### DIFF
--- a/src/pages/join/JoinTimePage.css
+++ b/src/pages/join/JoinTimePage.css
@@ -15,10 +15,7 @@
 .join-time-container {
   box-sizing: border-box;
   width: min(393px, calc(100vw - 40px));
-  height: min(
-    852px,
-    calc(100dvh - 40px - env(safe-area-inset-top) - env(safe-area-inset-bottom))
-  );
+  height: min(852px, calc(100dvh - 40px - env(safe-area-inset-top) - env(safe-area-inset-bottom)));
   margin: 0 auto;
   background-color: #f1f2f5;
   display: flex;
@@ -176,32 +173,41 @@
   --time-col: 46px;
   --time-gap: 10px;
 
-  --rail-top: 8px;
-  --grid-top: 36px;
-
-  --time-rail-top: 28px;
+  /* grid-scroll과 time-rail은 이 위치에서 시작함 (date-row 포함) */
+  --scroll-top: 8px;
 
   --radius: 5px;
 
   --rail-left: 0px;
   --grid-right: 0px;
-  --grid-bottom: 0px;
   --visible-rows: 12;
+
+  /* date-row + visible-rows만큼의 스크롤 영역 높이 */
+  --scroll-h: calc(
+    var(--date-row) + 6px + (var(--cell-h) * var(--visible-rows)) +
+      (var(--gap) * (var(--visible-rows) - 1))
+  );
 }
 
+/* jt-date-rail은 더 이상 사용하지 않음 (grid-scroll 내부로 이동) */
 .jt-date-rail {
-  position: absolute;
-  top: var(--rail-top);
-  left: calc(var(--time-col) + var(--time-gap));
-  right: var(--grid-right);
-  height: var(--date-row);
-  overflow: hidden;
+  display: none;
 }
 
+/* 날짜 헤더 행: grid-scroll 내부 sticky + 창 더 일치 */
 .jt-date-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   column-gap: var(--gap);
+}
+
+.jt-date-row--sticky {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #f1f2f5;
+  padding-bottom: 6px;
+  padding-top: 0;
 }
 
 .jt-date-header {
@@ -223,11 +229,11 @@
 
 .jt-time-rail {
   position: absolute;
-  top: var(--time-rail-top);
+  top: var(--scroll-top);
   left: var(--rail-left);
 
   width: var(--time-col);
-  height: calc((var(--cell-h) * var(--visible-rows)) + (var(--gap) * (var(--visible-rows) - 1)));
+  height: var(--scroll-h);
 
   overflow-y: auto;
   overflow-x: hidden;
@@ -267,23 +273,42 @@
   justify-content: flex-end;
 
   padding-right: 8px;
-  padding-top: 2px;
+  padding-top: 0;
 
   box-sizing: border-box;
   line-height: 1;
   white-space: nowrap;
+  overflow: visible;
+}
+
+/* 시간 텍스트를 경계선 중앙에 배치 (translateY -50%) */
+.jt-time-label-text {
+  display: block;
+  transform: translateY(-50%);
+  line-height: 1;
+}
+
+/* 시간 레일 주돃 - date-row 높이만큼 spacer */
+.jt-time-label--spacer {
+  height: calc(var(--date-row) + 6px);
+  min-height: calc(var(--date-row) + 6px);
+  pointer-events: none;
 }
 
 .jt-grid-scroll {
   position: absolute;
-  top: var(--grid-top);
+  top: var(--scroll-top);
   left: calc(var(--time-col) + var(--time-gap));
   right: var(--grid-right);
 
-  height: calc((var(--cell-h) * var(--visible-rows)) + (var(--gap) * (var(--visible-rows) - 1)));
+  height: var(--scroll-h);
 
   overflow-y: auto;
   overflow-x: hidden;
+
+  /* 스크롤바 숨김 */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 
   -webkit-overflow-scrolling: touch;
 
@@ -295,6 +320,10 @@
   touch-action: pan-y;
 }
 
+.jt-grid-scroll::-webkit-scrollbar {
+  display: none;
+}
+
 .jt-grid-scroll.is-selecting {
   overflow: hidden;
 }
@@ -304,10 +333,13 @@
   display: grid;
   column-gap: var(--gap);
   row-gap: var(--gap);
+  /* time-rail의 endLabel 높이만큼 스크롤 범위 확보 */
+  padding-bottom: calc(var(--cell-h) / 2);
+  box-sizing: content-box;
 }
 
 .jt-slot {
-  width: 100px;
+  width: 100%;
   height: var(--cell-h);
   box-sizing: border-box;
 
@@ -320,6 +352,12 @@
   -webkit-tap-highlight-color: transparent;
 
   touch-action: pan-y;
+}
+
+/* 마지막 endTime 레이블 (6PM 등): jt-grid의 padding-bottom과 높이 동일하게 */
+.jt-time-label--end {
+  height: calc(var(--cell-h) / 2);
+  min-height: 16px;
 }
 
 .jt-slot--top {

--- a/src/pages/join/JoinTimePage.jsx
+++ b/src/pages/join/JoinTimePage.jsx
@@ -137,8 +137,8 @@ function hmToMin(hm) {
 function buildTimeSlotsFromRange(startHm, endHm) {
   const startMin = hmToMin(startHm);
   const endMin = hmToMin(endHm);
-  if (startMin == null || endMin == null) return { labels: [], slots: [], apiHm: [] };
-  if (!(startMin < endMin)) return { labels: [], slots: [], apiHm: [] };
+  if (startMin == null || endMin == null) return { labels: [], slots: [], apiHm: [], endLabel: '' };
+  if (!(startMin < endMin)) return { labels: [], slots: [], apiHm: [], endLabel: '' };
 
   const slots = [];
   const labels = [];
@@ -162,7 +162,15 @@ function buildTimeSlotsFromRange(startHm, endHm) {
     cur += 30;
   }
 
-  return { labels, slots, apiHm };
+  // 마지막 시간(endTime) 레이블 생성
+  const eh = Math.floor(endMin / 60);
+  const em = endMin % 60;
+  const endIsPm = eh >= 12;
+  const endHour12 = ((eh + 11) % 12) + 1;
+  const endAmpm = endIsPm ? 'PM' : 'AM';
+  const endLabel = em === 0 ? `${endHour12} ${endAmpm}` : '';
+
+  return { labels, slots, apiHm, endLabel };
 }
 
 function makeKey(dateIndex, slotIndex) {
@@ -288,6 +296,7 @@ export default function JoinTimePage() {
     slots: TIME_SLOTS,
     labels: TIME_LABELS,
     apiHm: timeApiHm,
+    endLabel: TIME_END_LABEL,
   } = useMemo(() => {
     const s = eventData?.timeRange?.startTime;
     const e = eventData?.timeRange?.endTime;
@@ -703,8 +712,28 @@ export default function JoinTimePage() {
               onTouchEnd={onTouchEnd}
             >
               <div className="jt-frame">
-                <div className="jt-date-rail">
-                  <div className="jt-date-row">
+                <div ref={timeScrollRef} className="jt-time-rail" onScroll={syncFromTime}>
+                  <div className="jt-time-col">
+                    {/* 날짜 헤더 위 빈 공간 (date-row 높이만큼) */}
+                    <div className="jt-time-label jt-time-label--spacer" />
+                    {TIME_SLOTS.map((slot, idx) => (
+                      <div key={`${slot}-${idx}`} className="jt-time-label">
+                        {TIME_LABELS[idx] ? (
+                          <span className="jt-time-label-text">{TIME_LABELS[idx]}</span>
+                        ) : null}
+                      </div>
+                    ))}
+                    {TIME_END_LABEL && (
+                      <div className="jt-time-label jt-time-label--end">
+                        <span className="jt-time-label-text">{TIME_END_LABEL}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div ref={gridScrollRef} className="jt-grid-scroll" onScroll={syncFromGrid}>
+                  {/* 날짜 헤더: 그리드 스크롤 내부 상단 sticky */}
+                  <div className="jt-date-row jt-date-row--sticky">
                     {pageDatesFixed.map((d, i) => (
                       <div
                         key={`${page}-${d ?? 'empty'}-${i}`}
@@ -720,19 +749,6 @@ export default function JoinTimePage() {
                       </div>
                     ))}
                   </div>
-                </div>
-
-                <div ref={timeScrollRef} className="jt-time-rail" onScroll={syncFromTime}>
-                  <div className="jt-time-col">
-                    {TIME_SLOTS.map((slot, idx) => (
-                      <div key={`${slot}-${idx}`} className="jt-time-label">
-                        {TIME_LABELS[idx] ?? ''}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                <div ref={gridScrollRef} className="jt-grid-scroll" onScroll={syncFromGrid}>
                   <div
                     className="jt-grid"
                     style={{


### PR DESCRIPTION
- 마지막 열(03/12 목 등) 잘림 수정: jt-slot width 100px → 100%
- 종료 시간 레이블 미표시 수정: endLabel 추가 및 padding-bottom으로 스크롤 범위 확보
- 날짜 헤더 정렬 수정: jt-date-rail에서 jt-grid-scroll 내부 sticky 구조로 변경
- 시간 레이블 위치 수정: translateY(-50%)로 경계선 중앙에 배치